### PR TITLE
Wire WhatsApp export button to WhatsApp route

### DIFF
--- a/app/static/js/client-settings.js
+++ b/app/static/js/client-settings.js
@@ -226,8 +226,25 @@
         try {
           const data = JSON.parse(raw);
           if (data && typeof data === 'object') {
-            detail = typeof data.detail === 'string' ? data.detail : '';
-            reason = typeof data.reason === 'string' ? data.reason : '';
+            const detailValue = data.detail;
+            if (typeof detailValue === 'string') {
+              detail = detailValue;
+            } else if (Array.isArray(detailValue)) {
+              detail = detailValue.map((item) => (item == null ? '' : String(item))).filter(Boolean).join(', ');
+            } else if (detailValue && typeof detailValue === 'object') {
+              const detailParts = [];
+              Object.entries(detailValue).forEach(([key, value]) => {
+                if (value == null) return;
+                const text = Array.isArray(value) ? value.join(', ') : String(value);
+                detailParts.push(`${key}: ${text}`);
+              });
+              detail = detailParts.join('; ');
+            }
+
+            if (typeof data.reason === 'string') {
+              reason = data.reason;
+            }
+
             if (!detail && !reason && typeof data.message === 'string') {
               message = data.message;
             }
@@ -464,7 +481,7 @@
       try {
         const result = await requestWhatsappExport({ days, limit, per });
         if (result && result.empty) {
-          setStatus(dom.exportStatus, 'Нет диалогов за выбранный период', 'alert');
+          setStatus(dom.exportStatus, 'Нет диалогов за период', 'alert');
           return;
         }
 

--- a/app/web/client.py
+++ b/app/web/client.py
@@ -64,6 +64,16 @@ _wa_log = logging.getLogger("wa_export")
 MAX_UPLOAD_SIZE_BYTES = 25 * 1024 * 1024  # 25 MB safety cap for catalog uploads
 
 
+def _resolve_whatsapp_export_url(request: Request, tenant: int) -> str:
+    try:
+        return str(request.url_for("whatsapp_export", tenant=tenant))
+    except Exception:
+        try:
+            return str(request.url_for("whatsapp_export"))
+        except Exception:
+            return "/export/whatsapp"
+
+
 class WhatsAppExportPayload(BaseModel):
     tenant: int
     key: Optional[str] = None
@@ -275,7 +285,7 @@ def client_settings(tenant: int, request: Request):
             "training_upload": str(request.url_for("training_upload", tenant=tenant)),
             "training_status": str(request.url_for("training_status", tenant=tenant)),
             "training_export": str(request.url_for("training_export", tenant=tenant)),
-            "whatsapp_export": str(request.url_for("whatsapp_export", tenant=tenant)),
+            "whatsapp_export": _resolve_whatsapp_export_url(request, tenant),
         },
     }
     return templates.TemplateResponse("client/settings.html", context)


### PR DESCRIPTION
## Summary
- expose the WhatsApp export endpoint in the client settings state with a fallback when the route does not require a tenant path parameter
- improve the client settings export handler to surface API error details and update the empty-period status copy

## Testing
- pytest app/tests/test_whatsapp_export_safety.py

------
https://chatgpt.com/codex/tasks/task_e_68e52756f34c8323bb80d7d4e7f42fa3