### PR TITLE
Stream WhatsApp export responses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ FROM python-base AS app
 COPY app/ .
 EXPOSE 8000
 HEALTHCHECK CMD curl -fsS http://localhost:8000/health || exit 1
-CMD ["uvicorn","main:app","--host","0.0.0.0","--port","8000"]
+CMD ["uvicorn","main:app","--host","0.0.0.0","--port","8000","--timeout-keep-alive","5"]
 
 ######## worker ########
 FROM python-base AS worker

--- a/app/web/templates/client/settings.html
+++ b/app/web/templates/client/settings.html
@@ -152,7 +152,8 @@
       window.state = {{ {
         'tenant': tenant,
         'key': key,
-        'urls': urls
+        'urls': urls,
+        'max_days': max_days
       } | tojson | safe }};
     </script>
     <script src="/static/js/client-settings.js" defer></script>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - TENANTS_DIR=/app/tenants
     depends_on: [redis, postgres]
     working_dir: /app
-    command: ["uvicorn","main:app","--host","0.0.0.0","--port","8000"]
+    command: ["uvicorn","main:app","--host","0.0.0.0","--port","8000","--timeout-keep-alive","5"]
     restart: unless-stopped
 
     volumes:

--- a/migrations/019_messages_indexes.sql
+++ b/migrations/019_messages_indexes.sql
@@ -1,0 +1,10 @@
+-- Add indexes to speed up WhatsApp export queries
+
+CREATE INDEX IF NOT EXISTS idx_messages_tenant_channel_created_at
+    ON messages (tenant_id, channel, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_messages_lead_created_at
+    ON messages (lead_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_leads_tenant_channel
+    ON leads (tenant_id, channel);

--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -5,4 +5,4 @@ COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
 COPY app /app
 EXPOSE 8000
-CMD ["uvicorn","main:app","--host","0.0.0.0","--port","8000"]
+CMD ["uvicorn","main:app","--host","0.0.0.0","--port","8000","--timeout-keep-alive","5"]


### PR DESCRIPTION
## Summary
- stream WhatsApp exports from the database using on-disk spooling and batched loaders to avoid large in-memory archives
- add API safeguards for export limits and expose max-days to the client with corresponding UI validation
- tighten infrastructure settings and add database indexes to support the new streaming workload

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e52d3e975883239fd0e5ed971b4bcc