### PR TITLE
Fix bindExportClicks bootstrap order

### DIFF
--- a/app/static/js/client-settings.js
+++ b/app/static/js/client-settings.js
@@ -1,11 +1,3 @@
-function bindExportClicks(initialState) {
-  if (typeof window === 'undefined') return;
-  const impl = window.__bindExportClicksImpl;
-  if (typeof impl === 'function') {
-    impl(initialState);
-  }
-}
-
 (function () {
   const stateScript = document.getElementById('client-settings-state');
   const globalState = typeof window !== 'undefined' ? window.state : undefined;
@@ -685,5 +677,13 @@ function bindExportClicks(initialState) {
     window.__bindExportClicksImpl = bindExportClicksImpl;
   }
 })();
+
+function bindExportClicks(initialState) {
+  if (typeof window === 'undefined') return;
+  const impl = window.__bindExportClicksImpl;
+  if (typeof impl === 'function') {
+    impl(initialState);
+  }
+}
 
 bindExportClicks(window.state);


### PR DESCRIPTION
## Summary
- move the bindExportClicks helper declaration below the bootstrap IIFE so the script executes correctly when loaded without modules

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5406dff708323bbfaa11ce7816d36