### PR TITLE
Fix client settings WhatsApp export script

### DIFF
--- a/app/static/js/client-settings.js
+++ b/app/static/js/client-settings.js
@@ -1,3 +1,5 @@
+console.info('[client-settings] script loaded');
+
 (function () {
   const stateScript = document.getElementById('client-settings-state');
   const globalState = typeof window !== 'undefined' ? window.state : undefined;
@@ -678,12 +680,12 @@
   }
 })();
 
-const bindExportClicks = (initialState) => {
+function bindExportClicks(initialState) {
   if (typeof window === 'undefined') return;
   const impl = window.__bindExportClicksImpl;
   if (typeof impl === 'function') {
     impl(initialState);
   }
-};
+}
 
 bindExportClicks(window.state);

--- a/app/web/templates/client/settings.html
+++ b/app/web/templates/client/settings.html
@@ -149,14 +149,9 @@
     
 
     <script id="client-settings-state">
-      window.state = {{ {
-        'tenant': tenant,
-        'key': key,
-        'urls': urls,
-        'max_days': max_days
-      } | tojson | safe }};
+      window.state = {{ state | tojson | safe }};
     </script>
-    <script src="/static/js/client-settings.js" defer></script>
+    <script src="{{ static_url(request, 'js/client-settings.js') }}?v={{ client_settings_version }}" defer></script>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a cached Git short SHA helper and include it in the client settings context
- render the WhatsApp export URL inside the state blob and load the JS bundle with a versioned URL
- log client-settings script load and expose bindExportClicks as a top-level function

## Testing
- pytest app/tests/test_client_settings.py *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68e545e7b07883239ce04a8465b728b9