### PR TITLE
Add Starlette dependency

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.115.0
+starlette==0.27.0
 uvicorn==0.28.0
 redis==5.0.7
 aiohttp==3.12.15


### PR DESCRIPTION
## Summary
- add an explicit starlette==0.27.0 pin to the application requirements so direct starlette imports remain available

## Testing
- pytest app/tests/test_main_catalog.py

------
https://chatgpt.com/codex/tasks/task_e_68e63f4dd75883239c59f31eda5dcaf9